### PR TITLE
Rename package name to rescript-react-on-rails

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "bs-react-on-rails",
+  "name": "rescript-react-on-rails",
   "sources": [
     "src",
     {


### PR DESCRIPTION
Package name in bsconfig.json is required to change to rescript-react-on-rails to match the package name in package.json